### PR TITLE
Fix geometry function

### DIFF
--- a/cjdb/modules/exceptions.py
+++ b/cjdb/modules/exceptions.py
@@ -74,3 +74,17 @@ class InconsistentCRSException(Exception):
                     "Use the '-I/--srid' flag to reproject everything "
                     "to a single specified CRS or modify source data or "
                     "create a new schema.")
+
+
+class InvalidLodException(Exception):
+    def __init__(self, *args):
+        if args:
+            self.msg = args[0]
+        else:
+            self.msg = None
+
+    def __str__(self):
+        if self.msg:
+            return f"{self.msg}"
+        else:
+            return """The Geomerty object has invalid value for 'lod'."""

--- a/cjdb/modules/extensions.py
+++ b/cjdb/modules/extensions.py
@@ -22,14 +22,10 @@ class ExtensionHandler:
                 try:
                     resp = requests.get(url, timeout=10)
                 except Exception as e:
-                    print(f"{url} didnt work: {e}")
+                    logger.error(e)
                     resp = None
 
-                if resp and resp.status_code != 200:
-                    print(f"{url} is shit")
-
                 if resp and resp.status_code == 200:
-                    print(f"{url} is working")
                     try:
                         ext_definition = json.loads(resp.text)
                         self.full_definitions[ext_name] = ext_definition

--- a/cjdb/modules/importer.py
+++ b/cjdb/modules/importer.py
@@ -464,7 +464,7 @@ class Importer:
 
         ground_geometry = get_ground_geometry(geometry, obj_id)
 
-        if (ground_geometry is None) is False:
+        if ground_geometry is not None:
             if not self.current.target_srid:
                 ground_geometry = func.st_geomfromtext(ground_geometry.wkt)
             else:

--- a/cjdb/modules/importer.py
+++ b/cjdb/modules/importer.py
@@ -234,7 +234,7 @@ class Importer:
         elif imported_files.first() and self.overwrite:
             logger.warning(
                 "File already imported. Overwriting all objects"
-                f"from source file {cj_metadata.source_file}")
+                f" from source file {cj_metadata.source_file}")
             imported_files.delete()
 
         different_srid = cj_metadata.different_srid_meta(self.session)

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -3,12 +3,9 @@ from pytest import approx
 from shapely.geometry import MultiPolygon, Polygon
 
 from cjdb.modules.exceptions import InvalidLodException
-from cjdb.modules.geometric import (
-    get_flattened_polygons_from_boundaries,
-    get_geometry_with_minimum_lod,
-    get_ground_geometry,
-    get_ground_surfaces,
-)
+from cjdb.modules.geometric import (get_flattened_polygons_from_boundaries,
+                                    get_geometry_with_minimum_lod,
+                                    get_ground_geometry, get_ground_surfaces)
 
 boundary_multipoint_single_point = [[121483.808, 484844.936, 0.0]]
 boundary_multipoint_many_points = [

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -1,41 +1,163 @@
 import pytest
+from pytest import approx
+from shapely.geometry import MultiPolygon, Polygon
 
 from cjdb.modules.exceptions import InvalidLodException
-from cjdb.modules.geometric import (get_geometry_with_minimum_lod)
+from cjdb.modules.geometric import (get_flattened_polygons_from_boundaries,
+                                    get_geometry_with_minimum_lod,
+                                    get_ground_geometry,
+                                    get_ground_geometry_mine,
+                                    get_surfaces_from_boundaries)
+
+boundary_multipoint_single_point = [[121483.808, 484844.936, 0.0]]
+boundary_multipoint_many_points = [
+    [121483.808, 484844.936, 0.0],
+    [121099.937, 485192.14, 0.0],
+]
+boundary_multiline_string = [
+    [[121483.808, 484844.936, 0.0], [121099.937, 485192.14, 0.0]],
+    [[121099.444, 485194.594, 0.0], [121093.329, 485196.323, 0.0]],
+]
+boundary_multisurface = [
+    [
+        [
+            [121099.937, 485192.14, 0.0],
+            [121099.444, 485194.594, 0.0],
+            [121094.05500000001, 485193.087, 0.0],
+            [121093.329, 485196.32399999996, 0.0],
+            [121083.838, 485194.19399999996, 0.0],
+            [121084.52900000001, 485190.83999999997, 0.0],
+            [121083.901, 485190.697, 0.0],
+            [121086.12700000001, 485180.77999999997, 0.0],
+            [121096.30500000001, 485183.064, 0.0],
+            [121100.3, 485165.266, 0.0],
+            [121105.697, 485166.477, 0.0],
+        ],
+        [
+            [121483.808, 484844.936, 0.0],
+            [121483.808, 484844.936, 0.0],
+            [121483.808, 484844.936, 0.0],
+            [121483.808, 484844.936, 0.0],
+        ],
+    ]
+]
+
+boundary_multisurface_not_nested = [
+    [
+        [
+            [121077.757, 485119.04699999996, 0.0],
+            [121066.90800000001, 485116.72599999997, 0.0],
+            [121066.88900000001, 485116.665, 0.0],
+            [121068.043, 485111.091, 0.0],
+            [121078.916, 485113.47599999997, 0.0],
+        ]
+    ]
+]
+
+boundary_solid = [
+    [
+        [[[0.0, 0.0, 1.0], [1.0, 0.0, 1.0], [1.0, 1.0, 1.0], [0.0, 1.0, 1.0]]],
+        [[[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [1.0, 0.0, 1.0], [0.0, 0.0, 1.0]]],
+        [[[1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [1.0, 1.0, 1.0], [1.0, 0.0, 1.0]]],
+        [[[1.0, 1.0, 0.0], [0.0, 1.0, 0.0], [0.0, 1.0, 1.0], [1.0, 1.0, 1.0]]],
+        [[[0.0, 1.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 1.0, 1.0]]],
+        [[[0.0, 1.0, 0.0], [1.0, 1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 0.0]]],
+    ]
+]
 
 geometry_1 = dict()
-geometry_1['boundaries'] = [[[[121099.937, 485192.14, 0.0],
-                            [121099.444, 485194.594, 0.0],
-                            [121094.05500000001, 485193.087, 0.0],
-                            [121093.329, 485196.32399999996, 0.0],
-                            [121083.838, 485194.19399999996, 0.0],
-                            [121084.52900000001, 485190.83999999997, 0.0],
-                            [121083.901, 485190.697, 0.0],
-                            [121086.12700000001, 485180.77999999997, 0.0],
-                            [121096.30500000001, 485183.064, 0.0],
-                            [121100.3, 485165.266, 0.0],
-                            [121105.697, 485166.477, 0.0]],
-                           [[121483.808, 484844.936, 0.0],
-                            [121483.808, 484844.936, 0.0],
-                            [121483.808, 484844.936, 0.0],
-                            [121483.808, 484844.936, 0.0]]]]
-geometry_1['lod'] = '1.2'
-geometry_1['type'] = 'MultiSurface'
+geometry_1["boundaries"] = boundary_multisurface
+geometry_1["lod"] = "1.2"
+geometry_1["type"] = "MultiSurface"
 
 geometry_2 = dict()
-geometry_2['boundaries'] = []
-geometry_2['lod'] = '0.0'
-geometry_2['type'] = 'MultiSurface'
+geometry_2["boundaries"] = boundary_multisurface_not_nested
+geometry_2["lod"] = "0.0"
+geometry_2["type"] = "MultiSurface"
 
 geometry_3 = dict()
-geometry_3['boundaries'] = []
-geometry_3['lod'] = '2.1'
-geometry_3['type'] = 'MultiSurface'
+geometry_3["boundaries"] = []
+geometry_3["lod"] = "2.1"
+geometry_3["type"] = "MultiSurface"
 
 geometry_4 = dict()
-geometry_4['boundaries'] = []
-geometry_4['lod'] = 'foo'
-geometry_4['type'] = 'MultiSurface'
+geometry_4["boundaries"] = []
+geometry_4["lod"] = "foo"
+geometry_4["type"] = "MultiSurface"
+
+geometry_5 = dict()
+geometry_5["boundaries"] = boundary_multisurface
+geometry_5["lod"] = "0"
+geometry_5["type"] = "MultiSurface"
+
+def test_get_surfaces_from_boundaries_multisurface():
+    res = get_surfaces_from_boundaries(boundary_multisurface)
+    print(res)
+    assert isinstance(res[0][0], Polygon)
+    assert isinstance(res[0][1], Polygon)
+
+
+def test_get_surfaces_from_boundaries_solid():
+    res = get_surfaces_from_boundaries(boundary_solid)
+    print(res)
+    assert isinstance(res[0][0][0], Polygon)
+
+
+def test_get_flattened_polygons_from_boundaries_multisurface():
+    res = get_flattened_polygons_from_boundaries(boundary_multisurface_not_nested)
+    print(res)
+    assert isinstance(res[0], Polygon)
+    assert res[0].exterior.coords[0][0] == approx(121077.757)
+    assert res[0].exterior.coords[0][1] == approx(485119.04699999996)
+    assert len(res) == 1
+
+
+def test_get_flattened_polygons_from_boundaries_solid():
+    res = get_flattened_polygons_from_boundaries(boundary_solid)
+    print(res)
+    assert isinstance(res[0], Polygon)
+
+
+# def test_get_geometries_from_boundaries_single_point():
+#     res = get_geometries_from_boundaries(boundary_multipoint_single_point)
+#     assert isinstance(res[0], Point)
+
+
+# def test_get_geometries_from_boundaries_multiple_points():
+#     res = get_geometries_from_boundaries(boundary_multipoint_many_points)
+#     assert isinstance(res[0], Point)
+#     assert isinstance(res[1], Point)
+
+
+# def test_get_geometries_from_boundaries_multiline_string():
+#     res = get_geometries_from_boundaries(boundary_multiline_string)
+#     print(res)
+#     assert isinstance(res[0][0], Point)
+#     assert res[0][0].x == approx(121483.808)
+#     assert res[0][0].y == approx(484844.936)
+#     assert res[0][0].z == approx(0.0)
+#     assert isinstance(res[0][1], Point)
+#     assert res[0][1].x == approx(121099.937)
+#     assert res[0][1].y == approx(485192.14)
+#     assert res[0][1].z == approx(0.0)
+#     assert isinstance(res[1][0], Point)
+#     assert res[1][0].x == approx(121099.444)
+#     assert res[1][0].y == approx(485194.594)
+#     assert res[1][0].z == approx(0.0)
+#     assert isinstance(res[1][1], Point)
+#     assert res[1][1].x == approx(121093.329)
+#     assert res[1][1].y == approx(485196.323)
+#     assert res[1][1].z == approx(0.0)
+
+
+# def test_get_geometries_from_boundaries_solid():
+#     res = get_geometries_from_boundaries(boundary_solid)
+#     print(res)
+#     print(type(res[0][0][0]))
+#     assert isinstance(res[0][0][0], Polygon)
+#     assert isinstance(res[0][1][0], Polygon)
+#     assert isinstance(res[0][2][0], Polygon)
+#     assert isinstance(res[0][3][0], Polygon)
 
 
 def test_get_geometry_with_minimum_lod_no_geom():
@@ -45,21 +167,32 @@ def test_get_geometry_with_minimum_lod_no_geom():
 
 def test_get_geometry_with_minimum_lod_single_geom():
     res = get_geometry_with_minimum_lod([geometry_1])
-    assert res['lod'] == '1.2'
+    assert res["lod"] == "1.2"
 
 
 def test_get_geometry_with_minimum_lod_multiple_geom():
     res = get_geometry_with_minimum_lod([geometry_1, geometry_2, geometry_3])
-    assert res['lod'] == '0.0'
+    assert res["lod"] == "0.0"
 
 
 def test_get_geometry_with_minimum_lod_wrong_value():
     with pytest.raises(InvalidLodException):
-        _ = get_geometry_with_minimum_lod([geometry_1,
-                                           geometry_2,
-                                           geometry_4])
+        _ = get_geometry_with_minimum_lod([geometry_1, geometry_2, geometry_4])
 
-# def test_get_ground_geometry():
-#     ground_geometry = get_ground_geometry([geometry_1], "test")
-#     pass
-#     assert ground_geometry is not None
+
+def test_get_ground_geometry():
+    ground_geometry = get_ground_geometry([geometry_2], "test")
+    print(ground_geometry)
+    assert isinstance(ground_geometry, MultiPolygon)
+
+
+def test_get_ground_geometry_mine():
+    ground_geometry1 = get_ground_geometry([geometry_2], "test")
+    ground_geometry2 = get_ground_geometry_mine([geometry_2], "test")
+    assert ground_geometry1 == MultiPolygon([ground_geometry2])
+
+
+def test_get_ground_geometry_mine():
+    ground_geometry1 = get_ground_geometry([geometry_5], "test")
+    ground_geometry2 = get_ground_geometry_mine([geometry_5], "test")
+    assert ground_geometry1 == MultiPolygon([ground_geometry2])

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -3,9 +3,12 @@ from pytest import approx
 from shapely.geometry import MultiPolygon, Polygon
 
 from cjdb.modules.exceptions import InvalidLodException
-from cjdb.modules.geometric import (get_flattened_polygons_from_boundaries,
-                                    get_geometry_with_minimum_lod,
-                                    get_ground_geometry)
+from cjdb.modules.geometric import (
+    get_flattened_polygons_from_boundaries,
+    get_geometry_with_minimum_lod,
+    get_ground_geometry,
+    get_ground_surfaces,
+)
 
 boundary_multipoint_single_point = [[121483.808, 484844.936, 0.0]]
 boundary_multipoint_many_points = [
@@ -95,7 +98,8 @@ geometry_6["type"] = "MultiSurface"
 
 
 def test_get_flattened_polygons_from_boundaries_multisurface():
-    res = get_flattened_polygons_from_boundaries(boundary_multisurface_not_nested)
+    res = get_flattened_polygons_from_boundaries(
+        boundary_multisurface_not_nested)
     assert isinstance(res[0], Polygon)
     assert res[0].exterior.coords[0][0] == approx(121077.757)
     assert res[0].exterior.coords[0][1] == approx(485119.04699999996)
@@ -137,3 +141,13 @@ def test_get_ground_geometry_surfaces():
     assert isinstance(ground_geometry, MultiPolygon)
     ground_geometry = get_ground_geometry([geometry_5], "test")
     assert isinstance(ground_geometry, MultiPolygon)
+
+
+def test_get_ground_surfaces():
+    surfaces = get_flattened_polygons_from_boundaries(boundary_solid)
+    ground_surfaces = get_ground_surfaces(surfaces)
+    assert ground_surfaces[0] == Polygon(((0, 1),
+                                          (1, 1),
+                                          (1, 0),
+                                          (0, 0),
+                                          (0, 1)))

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -1,0 +1,65 @@
+import pytest
+
+from cjdb.modules.exceptions import InvalidLodException
+from cjdb.modules.geometric import (get_geometry_with_minimum_lod)
+
+geometry_1 = dict()
+geometry_1['boundaries'] = [[[[121099.937, 485192.14, 0.0],
+                            [121099.444, 485194.594, 0.0],
+                            [121094.05500000001, 485193.087, 0.0],
+                            [121093.329, 485196.32399999996, 0.0],
+                            [121083.838, 485194.19399999996, 0.0],
+                            [121084.52900000001, 485190.83999999997, 0.0],
+                            [121083.901, 485190.697, 0.0],
+                            [121086.12700000001, 485180.77999999997, 0.0],
+                            [121096.30500000001, 485183.064, 0.0],
+                            [121100.3, 485165.266, 0.0],
+                            [121105.697, 485166.477, 0.0]],
+                           [[121483.808, 484844.936, 0.0],
+                            [121483.808, 484844.936, 0.0],
+                            [121483.808, 484844.936, 0.0],
+                            [121483.808, 484844.936, 0.0]]]]
+geometry_1['lod'] = '1.2'
+geometry_1['type'] = 'MultiSurface'
+
+geometry_2 = dict()
+geometry_2['boundaries'] = []
+geometry_2['lod'] = '0.0'
+geometry_2['type'] = 'MultiSurface'
+
+geometry_3 = dict()
+geometry_3['boundaries'] = []
+geometry_3['lod'] = '2.1'
+geometry_3['type'] = 'MultiSurface'
+
+geometry_4 = dict()
+geometry_4['boundaries'] = []
+geometry_4['lod'] = 'foo'
+geometry_4['type'] = 'MultiSurface'
+
+
+def test_get_geometry_with_minimum_lod_no_geom():
+    res = get_geometry_with_minimum_lod([])
+    assert res is None
+
+
+def test_get_geometry_with_minimum_lod_single_geom():
+    res = get_geometry_with_minimum_lod([geometry_1])
+    assert res['lod'] == '1.2'
+
+
+def test_get_geometry_with_minimum_lod_multiple_geom():
+    res = get_geometry_with_minimum_lod([geometry_1, geometry_2, geometry_3])
+    assert res['lod'] == '0.0'
+
+
+def test_get_geometry_with_minimum_lod_wrong_value():
+    with pytest.raises(InvalidLodException):
+        _ = get_geometry_with_minimum_lod([geometry_1,
+                                           geometry_2,
+                                           geometry_4])
+
+# def test_get_ground_geometry():
+#     ground_geometry = get_ground_geometry([geometry_1], "test")
+#     pass
+#     assert ground_geometry is not None

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -5,9 +5,7 @@ from shapely.geometry import MultiPolygon, Polygon
 from cjdb.modules.exceptions import InvalidLodException
 from cjdb.modules.geometric import (get_flattened_polygons_from_boundaries,
                                     get_geometry_with_minimum_lod,
-                                    get_ground_geometry,
-                                    get_ground_geometry_mine,
-                                    get_surfaces_from_boundaries)
+                                    get_ground_geometry)
 
 boundary_multipoint_single_point = [[121483.808, 484844.936, 0.0]]
 boundary_multipoint_many_points = [
@@ -90,22 +88,14 @@ geometry_5["boundaries"] = boundary_multisurface
 geometry_5["lod"] = "0"
 geometry_5["type"] = "MultiSurface"
 
-def test_get_surfaces_from_boundaries_multisurface():
-    res = get_surfaces_from_boundaries(boundary_multisurface)
-    print(res)
-    assert isinstance(res[0][0], Polygon)
-    assert isinstance(res[0][1], Polygon)
-
-
-def test_get_surfaces_from_boundaries_solid():
-    res = get_surfaces_from_boundaries(boundary_solid)
-    print(res)
-    assert isinstance(res[0][0][0], Polygon)
+geometry_6 = dict()
+geometry_6["boundaries"] = boundary_solid
+geometry_6["lod"] = "1.2"
+geometry_6["type"] = "MultiSurface"
 
 
 def test_get_flattened_polygons_from_boundaries_multisurface():
     res = get_flattened_polygons_from_boundaries(boundary_multisurface_not_nested)
-    print(res)
     assert isinstance(res[0], Polygon)
     assert res[0].exterior.coords[0][0] == approx(121077.757)
     assert res[0].exterior.coords[0][1] == approx(485119.04699999996)
@@ -114,50 +104,7 @@ def test_get_flattened_polygons_from_boundaries_multisurface():
 
 def test_get_flattened_polygons_from_boundaries_solid():
     res = get_flattened_polygons_from_boundaries(boundary_solid)
-    print(res)
     assert isinstance(res[0], Polygon)
-
-
-# def test_get_geometries_from_boundaries_single_point():
-#     res = get_geometries_from_boundaries(boundary_multipoint_single_point)
-#     assert isinstance(res[0], Point)
-
-
-# def test_get_geometries_from_boundaries_multiple_points():
-#     res = get_geometries_from_boundaries(boundary_multipoint_many_points)
-#     assert isinstance(res[0], Point)
-#     assert isinstance(res[1], Point)
-
-
-# def test_get_geometries_from_boundaries_multiline_string():
-#     res = get_geometries_from_boundaries(boundary_multiline_string)
-#     print(res)
-#     assert isinstance(res[0][0], Point)
-#     assert res[0][0].x == approx(121483.808)
-#     assert res[0][0].y == approx(484844.936)
-#     assert res[0][0].z == approx(0.0)
-#     assert isinstance(res[0][1], Point)
-#     assert res[0][1].x == approx(121099.937)
-#     assert res[0][1].y == approx(485192.14)
-#     assert res[0][1].z == approx(0.0)
-#     assert isinstance(res[1][0], Point)
-#     assert res[1][0].x == approx(121099.444)
-#     assert res[1][0].y == approx(485194.594)
-#     assert res[1][0].z == approx(0.0)
-#     assert isinstance(res[1][1], Point)
-#     assert res[1][1].x == approx(121093.329)
-#     assert res[1][1].y == approx(485196.323)
-#     assert res[1][1].z == approx(0.0)
-
-
-# def test_get_geometries_from_boundaries_solid():
-#     res = get_geometries_from_boundaries(boundary_solid)
-#     print(res)
-#     print(type(res[0][0][0]))
-#     assert isinstance(res[0][0][0], Polygon)
-#     assert isinstance(res[0][1][0], Polygon)
-#     assert isinstance(res[0][2][0], Polygon)
-#     assert isinstance(res[0][3][0], Polygon)
 
 
 def test_get_geometry_with_minimum_lod_no_geom():
@@ -182,17 +129,11 @@ def test_get_geometry_with_minimum_lod_wrong_value():
 
 def test_get_ground_geometry():
     ground_geometry = get_ground_geometry([geometry_2], "test")
-    print(ground_geometry)
     assert isinstance(ground_geometry, MultiPolygon)
 
 
-def test_get_ground_geometry_mine():
-    ground_geometry1 = get_ground_geometry([geometry_2], "test")
-    ground_geometry2 = get_ground_geometry_mine([geometry_2], "test")
-    assert ground_geometry1 == MultiPolygon([ground_geometry2])
-
-
-def test_get_ground_geometry_mine():
-    ground_geometry1 = get_ground_geometry([geometry_5], "test")
-    ground_geometry2 = get_ground_geometry_mine([geometry_5], "test")
-    assert ground_geometry1 == MultiPolygon([ground_geometry2])
+def test_get_ground_geometry_surfaces():
+    ground_geometry = get_ground_geometry([geometry_5], "test")
+    assert isinstance(ground_geometry, MultiPolygon)
+    ground_geometry = get_ground_geometry([geometry_5], "test")
+    assert isinstance(ground_geometry, MultiPolygon)


### PR DESCRIPTION
Fixing the ground surface extraction:

TODO:

1. Right now, if the geometry is "MultiPoint" or "MultiLineString", there is no ground geometry returned. As discussed, we should probably return a convex hull of the points to allow 2D queries to be performed on these objects too. 
2. If there is no LoD0 then we should search first the surface types to see if there are surface of "GroundSurface" available and consider only those. 
3. Add some more test for special cases. 
4. Check if the speed of the import has been affected