### PR TITLE
Ft/add skip post import functions

### DIFF
--- a/cjdb/cli.py
+++ b/cjdb/cli.py
@@ -8,6 +8,12 @@ from cjdb.modules.exporter import Exporter
 from cjdb.modules.utils import get_db_engine, get_db_psycopg_conn
 from cjdb.resources import strings as s
 
+def get_password(ctx, param, value):
+    if value is None and 'PGPASSWORD' in os.environ:
+        return os.environ['PGPASSWORD']
+    else:
+        return click.prompt("Password for database user", hide_input=True)
+
 
 @click.group()
 @click.version_option(
@@ -33,8 +39,9 @@ def cjdb(ctx):
 @click.option("--user", "-U", type=str, required=True, help=s.user_help)
 @click.password_option(
     help=s.password_help,
-    prompt="Password for database user",
-    confirmation_prompt=False
+    prompt=False,
+    confirmation_prompt=False,
+    callback=get_password
 )
 @click.option("--database", "-d",
               type=str,
@@ -127,8 +134,9 @@ def import_cj(
 @click.option("--user", "-U", type=str, default="postgres", help=s.user_help)
 @click.password_option(
     help=s.password_help,
-    prompt="Password for database user",
-    confirmation_prompt=False
+    prompt=False,
+    confirmation_prompt=False,
+    callback=get_password
 )
 @click.option("--database", "-d",
               type=str,

--- a/cjdb/cli.py
+++ b/cjdb/cli.py
@@ -90,6 +90,14 @@ def cjdb(ctx):
     default=False,
     help=s.transform_help,
 )
+@click.option(
+    "--skip-post-import",
+    "-S",
+    "skip_post_import",
+    is_flag=True,
+    default=False,
+    help="Skip post import functions",
+)
 def import_cj(
     filepath,
     host,
@@ -103,7 +111,8 @@ def import_cj(
     partial_indexed_attributes,
     ignore_repeated_file,
     overwrite,
-    transform
+    transform,
+    skip_post_import  # add this parameter
 ):
     """Import CityJSONL files to a PostgreSQL database.
     Example of cli command:
@@ -122,7 +131,8 @@ def import_cj(
         partial_indexed_attributes,
         ignore_repeated_file,
         overwrite,
-        transform
+        transform,
+        skip_post_import
     ) as imp:
         imp.run_import()
 


### PR DESCRIPTION
uploading lots of jsonl files (100.000+ files)  makes the process extremely slow because of the post_import queries. 
to prevent it, this PR adds -S or --skip-post-import to completely skip the post_import functionality. 

fixes https://github.com/cityjson/cjdb/issues/37